### PR TITLE
added jar-with-dependencies output

### DIFF
--- a/groovy-shell-client/pom.xml
+++ b/groovy-shell-client/pom.xml
@@ -21,6 +21,14 @@
 					<descriptors>
 						<descriptor>assembly.xml</descriptor>
 					</descriptors>
+                    <archive>
+                        <manifest>
+                            <mainClass>com.farpost.groovy.shell.GroovyShellClient</mainClass>
+                        </manifest>
+                    </archive>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
 				</configuration>
 				<executions>
 					<execution>


### PR DESCRIPTION
produce an extra jar with main class definition in manifest so we can run with "java -jar target/groovy-shell-client-1.2-jar-with-dependencies.jar" after assembly
