### PR TITLE
expose SshServer for easier override 

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -68,7 +68,7 @@ You can easily integrate Groovy Shell with Spring container:
 
 	<bean class="me.bazhenov.groovysh.spring.GroovyShellServiceBean"
 		p:port="6789"
-		p:lauchAtStart="true"
+		p:launchAtStart="true"
 		p:publishContextBeans="true"
 		p:bindings-ref="bindings"/>
 

--- a/README.markdown
+++ b/README.markdown
@@ -92,7 +92,7 @@ Archives will be placed in `groovy-shell-server/target/`.
 
 In order to simple run applications you can use `maven-exec` plugin:
 
-	mvn -f groovy-shell-server/pom.xml exec:java -Dexec.mainClass=com.iterative.groovy.service.Main
+	mvn -f groovy-shell-server/pom.xml exec:java -Dexec.mainClass=me.bazhenov.groovysh.Main
 
 Management
 ----------

--- a/README.markdown
+++ b/README.markdown
@@ -21,7 +21,7 @@ Just include following dependency in your `pom.xml`:
 	<dependency>
 		<groupId>me.bazhenov.groovy-shell</groupId>
 		<artifactId>groovy-shell-server</artifactId>
-		<version>1.5</version>
+		<version>1.6</version>
 	</dependency>
 
 Using

--- a/groovy-shell-server/pom.xml
+++ b/groovy-shell-server/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>me.bazhenov.groovy-shell</groupId>
 		<artifactId>groovy-shell-parent</artifactId>
-		<version>1.5</version>
+		<version>1.6</version>
 	</parent>
 
 	<dependencies>

--- a/groovy-shell-server/src/main/java/me/bazhenov/groovysh/GroovyShellCommand.java
+++ b/groovy-shell-server/src/main/java/me/bazhenov/groovysh/GroovyShellCommand.java
@@ -97,7 +97,7 @@ class GroovyShellCommand implements Command, SessionAware {
 			public void run() {
 				try {
 					SshTerminal.registerEnvironment(env);
-					shell.run();
+					shell.run("");
 					callback.onExit(0);
 				} catch (RuntimeException e) {
 					callback.onExit(-1, e.getMessage());

--- a/groovy-shell-server/src/main/java/me/bazhenov/groovysh/GroovyShellService.java
+++ b/groovy-shell-server/src/main/java/me/bazhenov/groovysh/GroovyShellService.java
@@ -17,6 +17,7 @@ package me.bazhenov.groovysh;
 
 import org.apache.sshd.SshServer;
 import org.apache.sshd.common.Factory;
+import org.apache.sshd.common.KeyPairProvider;
 import org.apache.sshd.common.NamedFactory;
 import org.apache.sshd.common.Session;
 import org.apache.sshd.common.SessionListener;
@@ -53,6 +54,7 @@ public class GroovyShellService {
 
 	private List<String> defaultScripts = new ArrayList<String>();
 	private SshServer sshd;
+    private KeyPairProvider keyPairProvider = new SimpleGeneratorHostKeyProvider("host.key");
 
 	/**
 	 * Uses a default port of 6789
@@ -109,7 +111,11 @@ public class GroovyShellService {
 		this.defaultScripts = defaultScriptNames;
 	}
 
-	/**
+    public void setKeyPairProvider(KeyPairProvider keyPairProvider) {
+        this.keyPairProvider = keyPairProvider;
+    }
+
+    /**
 	 * Starts Groovysh
 	 *
 	 * @throws IOException thrown if socket cannot be opened
@@ -144,7 +150,7 @@ public class GroovyShellService {
 		});
 		sshd.setSessionFactory(sessionFactory);
 
-		sshd.setKeyPairProvider(new SimpleGeneratorHostKeyProvider("host.key"));
+		sshd.setKeyPairProvider(keyPairProvider);
 		NamedFactory<UserAuth> a = new UserAuthNone.Factory();
 		sshd.setUserAuthFactories(asList(a));
 		sshd.setShellFactory(new GroovyShellFactory());

--- a/groovy-shell-server/src/main/java/me/bazhenov/groovysh/spring/GroovyShellServiceBean.java
+++ b/groovy-shell-server/src/main/java/me/bazhenov/groovysh/spring/GroovyShellServiceBean.java
@@ -22,10 +22,14 @@ public class GroovyShellServiceBean implements InitializingBean, DisposableBean,
 	private boolean publishContextBeans = true;
 
 	public GroovyShellServiceBean() {
-		this.service = new GroovyShellService();
+		this.service = newService();
 	}
 
-	public void setPort(int port) {
+    protected GroovyShellService newService() {
+        return new GroovyShellService();
+    }
+
+    public void setPort(int port) {
 		service.setPort(port);
 	}
 
@@ -48,7 +52,11 @@ public class GroovyShellServiceBean implements InitializingBean, DisposableBean,
 		service.setBindings(bindings);
 	}
 
-	/**
+    protected GroovyShellService getService() {
+        return service;
+    }
+
+    /**
 	 * Set the comma delimited list of default scripts
 	 *
 	 * @param scriptNames script names
@@ -57,10 +65,6 @@ public class GroovyShellServiceBean implements InitializingBean, DisposableBean,
 		if (!scriptNames.trim().isEmpty())
 			service.setDefaultScripts(asList(scriptNames.split(",")));
 	}
-
-    public void setKeyPairProvider(KeyPairProvider keyPairProvider) {
-        service.setKeyPairProvider(keyPairProvider);
-    }
 
 	@Override
 	public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {

--- a/groovy-shell-server/src/main/java/me/bazhenov/groovysh/spring/GroovyShellServiceBean.java
+++ b/groovy-shell-server/src/main/java/me/bazhenov/groovysh/spring/GroovyShellServiceBean.java
@@ -1,6 +1,7 @@
 package me.bazhenov.groovysh.spring;
 
 import me.bazhenov.groovysh.GroovyShellService;
+import org.apache.sshd.common.KeyPairProvider;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.InitializingBean;
@@ -56,6 +57,10 @@ public class GroovyShellServiceBean implements InitializingBean, DisposableBean,
 		if (!scriptNames.trim().isEmpty())
 			service.setDefaultScripts(asList(scriptNames.split(",")));
 	}
+
+    public void setKeyPairProvider(KeyPairProvider keyPairProvider) {
+        service.setKeyPairProvider(keyPairProvider);
+    }
 
 	@Override
 	public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>me.bazhenov.groovy-shell</groupId>
 	<artifactId>groovy-shell-parent</artifactId>
 	<packaging>pom</packaging>
-	<version>1.5</version>
+	<version>1.6</version>
 	<name>Groovy Shell</name>
 	<url>https://github.com/bazhenov/groovy-shell-server</url>
 


### PR DESCRIPTION
1. update outdated `README` file
2. expose `SshServer` from `GroovyShellService` as protected to allow override
3. use `Groovysh#run()` to be compatible with groovy-2.4