### PR TITLE
Use custom ThreadFactory to name GroovyShellService threads

### DIFF
--- a/groovy-shell-server/src/main/java/me/bazhenov/groovysh/GroovyShellService.java
+++ b/groovy-shell-server/src/main/java/me/bazhenov/groovysh/GroovyShellService.java
@@ -15,6 +15,9 @@
  */
 package me.bazhenov.groovysh;
 
+import me.bazhenov.groovysh.thread.DefaultGroovyshThreadFactory;
+import me.bazhenov.groovysh.thread.ServerSessionAwareThreadFactory;
+
 import org.apache.sshd.SshServer;
 import org.apache.sshd.common.Factory;
 import org.apache.sshd.common.NamedFactory;
@@ -56,6 +59,7 @@ public class GroovyShellService {
 	private String host;
 	private Map<String, Object> bindings;
 	private PasswordAuthenticator passwordAuthenticator;
+	private ServerSessionAwareThreadFactory threadFactory = new DefaultGroovyshThreadFactory();
 
 	private List<String> defaultScripts = new ArrayList<String>();
 	private SshServer sshd;
@@ -113,6 +117,10 @@ public class GroovyShellService {
 
 	public void setPasswordAuthenticator (PasswordAuthenticator passwordAuthenticator) {
 		this.passwordAuthenticator = passwordAuthenticator;
+	}
+
+	public void setThreadFactory(ServerSessionAwareThreadFactory threadFactory) {
+	    this.threadFactory = threadFactory;
 	}
 
 	public void setDefaultScripts(List<String> defaultScriptNames) {
@@ -184,7 +192,7 @@ public class GroovyShellService {
 
 		@Override
 		public Command create() {
-			return new GroovyShellCommand(sshd, bindings, defaultScripts);
+			return new GroovyShellCommand(sshd, bindings, defaultScripts, threadFactory);
 		}
 	}
 }

--- a/groovy-shell-server/src/main/java/me/bazhenov/groovysh/spring/GroovyShellServiceBean.java
+++ b/groovy-shell-server/src/main/java/me/bazhenov/groovysh/spring/GroovyShellServiceBean.java
@@ -1,6 +1,7 @@
 package me.bazhenov.groovysh.spring;
 
 import me.bazhenov.groovysh.GroovyShellService;
+import me.bazhenov.groovysh.thread.ServerSessionAwareThreadFactory;
 
 import org.apache.sshd.server.PasswordAuthenticator;
 import org.springframework.beans.BeansException;
@@ -60,6 +61,10 @@ public class GroovyShellServiceBean implements InitializingBean, DisposableBean,
 
 	public void setPasswordAuthenticator(PasswordAuthenticator passwordAuthenticator) {
 		service.setPasswordAuthenticator(passwordAuthenticator);
+	}
+
+	public void setThreadFactory(ServerSessionAwareThreadFactory threadFactory) {
+	    service.setThreadFactory(threadFactory);
 	}
 
 	/**

--- a/groovy-shell-server/src/main/java/me/bazhenov/groovysh/thread/DefaultGroovyshThreadFactory.java
+++ b/groovy-shell-server/src/main/java/me/bazhenov/groovysh/thread/DefaultGroovyshThreadFactory.java
@@ -1,0 +1,12 @@
+package me.bazhenov.groovysh.thread;
+
+import org.apache.sshd.server.session.ServerSession;
+
+public class DefaultGroovyshThreadFactory implements ServerSessionAwareThreadFactory {
+
+    @Override
+    public Thread newThread(Runnable runnable, ServerSession session) {
+        String threadName = "GroovySh Client Thread: " + session.getIoSession().getRemoteAddress().toString();
+        return new Thread(runnable, threadName);
+    }
+}

--- a/groovy-shell-server/src/main/java/me/bazhenov/groovysh/thread/ServerSessionAwareThreadFactory.java
+++ b/groovy-shell-server/src/main/java/me/bazhenov/groovysh/thread/ServerSessionAwareThreadFactory.java
@@ -1,0 +1,9 @@
+package me.bazhenov.groovysh.thread;
+
+import org.apache.sshd.server.session.ServerSession;
+
+public interface ServerSessionAwareThreadFactory {
+
+	Thread newThread(Runnable runnable, ServerSession session);
+
+}


### PR DESCRIPTION
It turned out we want to use custom thread names in Groovy Shell Service, so i implemented such possibility. If you like it, you can merge it into your code.