### PR TITLE
Upgrade Apache SSHD to 1.2.0

### DIFF
--- a/groovy-shell-server/pom.xml
+++ b/groovy-shell-server/pom.xml
@@ -30,7 +30,7 @@
 		<dependency>
 			<groupId>org.apache.sshd</groupId>
 			<artifactId>sshd-core</artifactId>
-			<version>0.11.0</version>
+			<version>0.14.0</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/groovy-shell-server/pom.xml
+++ b/groovy-shell-server/pom.xml
@@ -30,7 +30,7 @@
 		<dependency>
 			<groupId>org.apache.sshd</groupId>
 			<artifactId>sshd-core</artifactId>
-			<version>0.14.0</version>
+			<version>1.2.0</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/groovy-shell-server/src/main/java/me/bazhenov/groovysh/GroovyShellCommand.java
+++ b/groovy-shell-server/src/main/java/me/bazhenov/groovysh/GroovyShellCommand.java
@@ -3,19 +3,23 @@ package me.bazhenov.groovysh;
 import groovy.lang.Binding;
 import groovy.lang.Closure;
 import me.bazhenov.groovysh.thread.ServerSessionAwareThreadFactory;
-
-import org.apache.sshd.SshServer;
 import org.apache.sshd.common.SshException;
-import org.apache.sshd.common.session.AbstractSession;
+import org.apache.sshd.common.session.helpers.AbstractSession;
 import org.apache.sshd.server.Command;
 import org.apache.sshd.server.Environment;
 import org.apache.sshd.server.ExitCallback;
 import org.apache.sshd.server.SessionAware;
+import org.apache.sshd.server.SshServer;
 import org.apache.sshd.server.session.ServerSession;
 import org.codehaus.groovy.tools.shell.Groovysh;
 import org.codehaus.groovy.tools.shell.IO;
 
-import java.io.*;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InterruptedIOException;
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.io.UnsupportedEncodingException;
 import java.util.List;
 import java.util.Map;
 

--- a/groovy-shell-server/src/main/java/me/bazhenov/groovysh/spring/GroovyShellServiceBean.java
+++ b/groovy-shell-server/src/main/java/me/bazhenov/groovysh/spring/GroovyShellServiceBean.java
@@ -3,7 +3,7 @@ package me.bazhenov.groovysh.spring;
 import me.bazhenov.groovysh.GroovyShellService;
 import me.bazhenov.groovysh.thread.ServerSessionAwareThreadFactory;
 
-import org.apache.sshd.server.PasswordAuthenticator;
+import org.apache.sshd.server.auth.password.PasswordAuthenticator;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanIsAbstractException;
 import org.springframework.beans.factory.DisposableBean;


### PR DESCRIPTION
A downside to upgrading beyond 0.14.0 to 1.x.x is that these versions are API incompatible due to refactoring. The [CRaSH](https://github.com/crashub/crash) project has not upgraded beyond 0.11.0 yet, so both can't be run in the same application when using the CRaSH SSH Connector.