### PR TITLE
Upgrade Dependencies

### DIFF
--- a/groovy-shell-server/pom.xml
+++ b/groovy-shell-server/pom.xml
@@ -19,7 +19,7 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-context</artifactId>
-			<version>3.2.6.RELEASE</version>
+			<version>3.2.16.RELEASE</version>
 			<optional>true</optional>
 		</dependency>
 		<dependency>

--- a/groovy-shell-server/pom.xml
+++ b/groovy-shell-server/pom.xml
@@ -30,7 +30,7 @@
 		<dependency>
 			<groupId>org.apache.sshd</groupId>
 			<artifactId>sshd-core</artifactId>
-			<version>0.11.0</version>
+			<version>0.14.0</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/groovy-shell-server/pom.xml
+++ b/groovy-shell-server/pom.xml
@@ -17,11 +17,6 @@
 			<version>2.2.2</version>
 		</dependency>
 		<dependency>
-			<groupId>org.fusesource.jansi</groupId>
-			<artifactId>jansi</artifactId>
-			<version>1.11</version>
-		</dependency>
-		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-context</artifactId>
 			<version>3.2.6.RELEASE</version>

--- a/groovy-shell-server/pom.xml
+++ b/groovy-shell-server/pom.xml
@@ -28,6 +28,11 @@
 			<version>0.14.0</version>
 		</dependency>
 		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+			<version>1.7.16</version>
+		</dependency>
+		<dependency>
 			<groupId>jline</groupId>
 			<artifactId>jline</artifactId>
 			<version>2.12.1</version>

--- a/groovy-shell-server/pom.xml
+++ b/groovy-shell-server/pom.xml
@@ -33,6 +33,13 @@
 			<version>1.7.16</version>
 		</dependency>
 		<dependency>
+			<groupId>ch.qos.logback</groupId>
+			<artifactId>logback-classic</artifactId>
+			<version>1.1.5</version>
+			<scope>runtime</scope>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
 			<groupId>jline</groupId>
 			<artifactId>jline</artifactId>
 			<version>2.12.1</version>

--- a/groovy-shell-server/pom.xml
+++ b/groovy-shell-server/pom.xml
@@ -27,5 +27,10 @@
 			<artifactId>sshd-core</artifactId>
 			<version>0.14.0</version>
 		</dependency>
+		<dependency>
+			<groupId>jline</groupId>
+			<artifactId>jline</artifactId>
+			<version>2.12.1</version>
+		</dependency>
 	</dependencies>
 </project>

--- a/groovy-shell-server/pom.xml
+++ b/groovy-shell-server/pom.xml
@@ -14,7 +14,7 @@
 		<dependency>
 			<groupId>org.codehaus.groovy</groupId>
 			<artifactId>groovy-all</artifactId>
-			<version>2.2.2</version>
+			<version>2.3.11</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -124,12 +124,4 @@
 		</plugins>
 	</build>
 
-	<dependencies>
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-api</artifactId>
-			<version>1.6.1</version>
-		</dependency>
-	</dependencies>
-
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -130,17 +130,6 @@
 			<artifactId>slf4j-api</artifactId>
 			<version>1.6.1</version>
 		</dependency>
-		<dependency>
-			<groupId>jline</groupId>
-			<artifactId>jline</artifactId>
-			<version>2.11</version>
-			<exclusions>
-				<exclusion>
-					<groupId>junit</groupId>
-					<artifactId>junit</artifactId>
-				</exclusion>
-			</exclusions>
-		</dependency>
 	</dependencies>
 
 </project>


### PR DESCRIPTION
These upgrades should all be safe. I had to stop at Apache SSHD 0.14.0 due to API incompatibility with 1.0.x and beyond. I noticed that backspace didn't work properly in JLine 2.13 and later including 2.14.1, so I stopped at 2.12.1. Jansi is already bundled with JLine so the dependency can be safely removed. Groovy needs to be held back to 2.3.11 due to a [bug](https://issues.apache.org/jira/browse/GROOVY-7562) in Groovysh Interpreter Mode in Groovy 2.4.x that prevents imports from working.
