### PR TITLE
Sometimes, COLUMNS=0 making other part of the application break

### DIFF
--- a/groovy-shell-server/src/main/java/me/bazhenov/groovysh/SshTerminal.java
+++ b/groovy-shell-server/src/main/java/me/bazhenov/groovysh/SshTerminal.java
@@ -20,7 +20,11 @@ public class SshTerminal extends UnixTerminal {
 	public int getWidth() {
 		Environment environment = retrieveEnvironment();
 		try {
-			return parseInt(environment.getEnv().get("COLUMNS"));
+			int columns = parseInt(environment.getEnv().get("COLUMNS"));
+			if (columns == 0) {
+				return DEFAULT_WIDTH;
+			}
+			return columns;
 		} catch (NumberFormatException e) {
 			return DEFAULT_WIDTH;
 		}
@@ -30,7 +34,11 @@ public class SshTerminal extends UnixTerminal {
 	public int getHeight() {
 		Environment environment = retrieveEnvironment();
 		try {
-			return parseInt(environment.getEnv().get("LINES"));
+			int lines = parseInt(environment.getEnv().get("LINES"));
+			if (lines == 0) {
+				return DEFAULT_HEIGHT;
+			}
+			return lines;
 		} catch (NumberFormatException e) {
 			return DEFAULT_HEIGHT;
 		}


### PR DESCRIPTION
Hello !
Thanks for the great repo, it's very useful to us.

Unfortunately we (sometimes?) hit a bug where "COLUMNS" = 0 (I didn't find why, do not hesitate if you want more info on our setup).
There is some code in JLine that do (ConsoleReader, line 2087):
```
        int width = getTerminal().getWidth();
        int l0 = i0 / width;
        int c0 = i0 % width;
        int l1 = i1 / width;
        int c1 = i1 % width;
```

With Columns = 0, `getWidth()` returns 0, we get an `java.lang.ArithmeticException` (divide by zero) everytime we try to move the cursor.

