### PR TITLE
updated groovy version to 3.0.4

### DIFF
--- a/groovy-shell-server/pom.xml
+++ b/groovy-shell-server/pom.xml
@@ -11,7 +11,7 @@
 	</parent>
 
 	<properties>
-		<versions.groovy>2.5.8</versions.groovy>
+		<versions.groovy>3.0.4</versions.groovy>
 	</properties>
 
 	<dependencies>

--- a/groovy-shell-server/src/main/java/me/bazhenov/groovysh/GroovyShellCommand.java
+++ b/groovy-shell-server/src/main/java/me/bazhenov/groovysh/GroovyShellCommand.java
@@ -11,7 +11,7 @@ import org.apache.sshd.server.SessionAware;
 import org.apache.sshd.server.SshServer;
 import org.apache.sshd.server.command.Command;
 import org.apache.sshd.server.session.ServerSession;
-import org.codehaus.groovy.tools.shell.Groovysh;
+import org.apache.groovy.groovysh.Groovysh;
 import org.codehaus.groovy.tools.shell.IO;
 
 import java.io.*;
@@ -75,7 +75,7 @@ class GroovyShellCommand implements Command, SessionAware {
 		IO io = new IO(in, out, err);
 		io.setVerbosity(IO.Verbosity.DEBUG);
 		Groovysh shell = new Groovysh(createBinding(bindings, out, err), io);
-		shell.setErrorHook(new Closure(this) {
+		shell.setErrorHook(new Closure<Object>(this) {
 			@Override
 			public Object call(Object... args) {
 				if (args[0] instanceof InterruptedIOException || args[0] instanceof SshException) {
@@ -145,7 +145,7 @@ class GroovyShellCommand implements Command, SessionAware {
 					}
 				});
 
-				org.codehaus.groovy.tools.shell.Command cmd = shell.getRegistry().find(":load");
+				org.apache.groovy.groovysh.Command cmd = shell.getRegistry().find(":load");
 				for (String script : defaultScripts) {
 					cmd.execute(singletonList(script));
 				}

--- a/groovy-shell-server/src/main/java/me/bazhenov/groovysh/GroovyShellService.java
+++ b/groovy-shell-server/src/main/java/me/bazhenov/groovysh/GroovyShellService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2007 Bruce Fancher
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
@@ -26,7 +26,7 @@ import org.apache.sshd.server.auth.password.PasswordAuthenticator;
 import org.apache.sshd.server.auth.password.UserAuthPasswordFactory;
 import org.apache.sshd.server.command.Command;
 import org.apache.sshd.server.keyprovider.SimpleGeneratorHostKeyProvider;
-import org.codehaus.groovy.tools.shell.Groovysh;
+import org.apache.groovy.groovysh.Groovysh;
 import org.codehaus.groovy.tools.shell.util.Preferences;
 
 import java.io.File;
@@ -41,7 +41,7 @@ import static jline.TerminalFactory.Flavor.UNIX;
 import static jline.TerminalFactory.registerFlavor;
 import static org.apache.sshd.common.FactoryManager.IDLE_TIMEOUT;
 import static org.apache.sshd.server.SshServer.setUpDefaultServer;
-import static org.codehaus.groovy.tools.shell.util.PackageHelper.IMPORT_COMPLETION_PREFERENCE_KEY;
+import static org.apache.groovy.groovysh.util.PackageHelper.IMPORT_COMPLETION_PREFERENCE_KEY;
 
 /**
  * Instantiate this class and call {@link #start()} to start a GroovyShell

--- a/groovy-shell-server/src/main/java/me/bazhenov/groovysh/Main.java
+++ b/groovy-shell-server/src/main/java/me/bazhenov/groovysh/Main.java
@@ -6,6 +6,7 @@ import static java.lang.Thread.currentThread;
 
 public class Main {
 
+	@SuppressWarnings("BusyWait")
 	public static void main(String[] args) throws IOException, InterruptedException {
 		GroovyShellService service = new GroovyShellService();
 		service.setPort(6789);


### PR DESCRIPTION
Groovy 2.5.9 caused warning on java 11 - WARNING: Illegal reflective access by org.codehaus.groovy.reflection.CachedClass, so I updated it to 3.0.4.