### PR TITLE
Проверка статуса ssh канала перед записью.

### DIFF
--- a/groovy-shell-server/pom.xml
+++ b/groovy-shell-server/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>me.bazhenov.groovy-shell</groupId>
 		<artifactId>groovy-shell-parent</artifactId>
-		<version>2.1.0-SNAPSHOT</version>
+		<version>2.1.1-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/groovy-shell-server/src/main/java/me/bazhenov/groovysh/GroovyShellService.java
+++ b/groovy-shell-server/src/main/java/me/bazhenov/groovysh/GroovyShellService.java
@@ -160,7 +160,7 @@ public class GroovyShellService {
 			sshd.setHost(host);
 		}
 
-		PropertyResolverUtils.updateProperty(sshd, IDLE_TIMEOUT, HOURS.toMillis(1));
+		PropertyResolverUtils.updateProperty(sshd, IDLE_TIMEOUT, HOURS.toMillis(9));
 
 		sshd.addSessionListener(new SessionListener() {
 			@Override

--- a/groovy-shell-server/src/main/java/me/bazhenov/groovysh/TtyFilterOutputStream.java
+++ b/groovy-shell-server/src/main/java/me/bazhenov/groovysh/TtyFilterOutputStream.java
@@ -3,26 +3,51 @@ package me.bazhenov.groovysh;
 import java.io.FilterOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 class TtyFilterOutputStream extends FilterOutputStream {
 
-	TtyFilterOutputStream(OutputStream out) {
+	/**
+	 * Существует сценарий (как например при ручном вызове 'groovyShell.destroy()' из сессии самого GroovyShell),
+	 * при котором результат команды не может быть отображен пользователю GroovyShell,
+	 * поскольку ssh канал уже закрыт, что вызывает рекурсивный поток ошибок
+	 * при попытке вывести пользователю уже исключение, что засоряет логи
+	 * приложения эксплуатирующего GroovyShellServiceBean (см. SR-1121).
+	 * <p>
+	 * Поэтому, добавляем здесь явную проверку что ssh-канал для записи жив,
+	 * чтобы погасить SshChannelClosedException в родительском классе и избежать такой рекурсии.
+	 */
+	private final AtomicBoolean isChannelAlive;
+
+	TtyFilterOutputStream(OutputStream out, AtomicBoolean isChannelAlive) {
 		super(out);
+		this.isChannelAlive = isChannelAlive;
 	}
 
 	@Override
 	public void write(int c) throws IOException {
-		if (c == '\n') {
+		if (isChannelAlive.get()) {
+			if (c == '\n') {
+				super.write(c);
+				c = '\r';
+			}
 			super.write(c);
-			c = '\r';
 		}
-		super.write(c);
+	}
+
+	@Override
+	public void flush() throws IOException {
+		if (isChannelAlive.get()) {
+			super.flush();
+		}
 	}
 
 	@Override
 	public void write(byte[] b, int off, int len) throws IOException {
-		for (int i = off; i < len; i++) {
-			write(b[i]);
+		if (isChannelAlive.get()) {
+			for (int i = off; i < len; i++) {
+				write(b[i]);
+			}
 		}
 	}
 }

--- a/groovy-shell-server/src/main/java/me/bazhenov/groovysh/TtyFilterOutputStream.java
+++ b/groovy-shell-server/src/main/java/me/bazhenov/groovysh/TtyFilterOutputStream.java
@@ -8,14 +8,15 @@ import java.util.concurrent.atomic.AtomicBoolean;
 class TtyFilterOutputStream extends FilterOutputStream {
 
 	/**
-	 * Существует сценарий (как например при ручном вызове 'groovyShell.destroy()' из сессии самого GroovyShell),
-	 * при котором результат команды не может быть отображен пользователю GroovyShell,
-	 * поскольку ssh канал уже закрыт, что вызывает рекурсивный поток ошибок
-	 * при попытке вывести пользователю уже исключение, что засоряет логи
-	 * приложения эксплуатирующего GroovyShellServiceBean (см. SR-1121).
+	 * There is a some cases ('groovyShell.destroy()' called from GroovyShell session for example)
+	 * when the result of the command cannot be displayed to the GroovyShell user,
+	 * because the ssh channel is already closed.
+	 * The error message that has occurred cannot be displayed either.
+	 * This causes a stream of recursive errors to fill up application logs.
 	 * <p>
-	 * Поэтому, добавляем здесь явную проверку что ssh-канал для записи жив,
-	 * чтобы погасить SshChannelClosedException в родительском классе и избежать такой рекурсии.
+	 * Therefore, we add here an explicit check that the ssh channel is alive,
+	 * in order to extinguish the SshChannelClosedException
+	 * in the parent class and avoid such recursion.
 	 */
 	private final AtomicBoolean isChannelAlive;
 

--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@
 							<execution>
 								<phase>install</phase>
 								<goals>
-									<goal>sign</goal>
+									<!--<goal>sign</goal>-->
 								</goals>
 							</execution>
 						</executions>

--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@
 							<execution>
 								<phase>install</phase>
 								<goals>
-									<!--<goal>sign</goal>-->
+									<goal>sign</goal>
 								</goals>
 							</execution>
 						</executions>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>me.bazhenov.groovy-shell</groupId>
 	<artifactId>groovy-shell-parent</artifactId>
 	<packaging>pom</packaging>
-	<version>2.1.0-SNAPSHOT</version>
+	<version>2.1.1-SNAPSHOT</version>
 	<name>Groovy Shell</name>
 	<url>https://github.com/bazhenov/groovy-shell-server</url>
 


### PR DESCRIPTION
Существует редкий сценарий, как, например при ручном вызове 'groovyShell.destroy()' из сессии самого GroovyShell, при котором результат команды не может быть отображен пользователю, поскольку ssh канал уже закрыт, что вызывает рекурсивный поток ошибок при попытке вывести пользователю уже исключение, что засоряет логи самого приложения эксплуатирующего GroovyShellServiceBean.
Решение:
Добавил явную проверку в записывающий поток для этого случая, чтобы погасить рекурсивный поток исключений и завершить работу.