### PR TITLE
Fixed endless cycle log + Configurable idle timeout

### DIFF
--- a/groovy-shell-server/src/main/java/me/bazhenov/groovysh/GroovyShellCommand.java
+++ b/groovy-shell-server/src/main/java/me/bazhenov/groovysh/GroovyShellCommand.java
@@ -1,20 +1,7 @@
 package me.bazhenov.groovysh;
 
-import static java.util.Collections.singletonList;
-import static me.bazhenov.groovysh.GroovyShellService.SHELL_KEY;
-import static org.codehaus.groovy.tools.shell.IO.Verbosity.DEBUG;
-
 import groovy.lang.Binding;
 import groovy.lang.Closure;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InterruptedIOException;
-import java.io.OutputStream;
-import java.io.PrintStream;
-import java.io.UnsupportedEncodingException;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.groovy.groovysh.Groovysh;
 import org.apache.sshd.common.SshException;
 import org.apache.sshd.common.session.helpers.AbstractSession;
@@ -24,6 +11,15 @@ import org.apache.sshd.server.SshServer;
 import org.apache.sshd.server.channel.ChannelSession;
 import org.apache.sshd.server.command.Command;
 import org.codehaus.groovy.tools.shell.IO;
+
+import java.io.*;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static java.util.Collections.singletonList;
+import static me.bazhenov.groovysh.GroovyShellService.SHELL_KEY;
+import static org.codehaus.groovy.tools.shell.IO.Verbosity.DEBUG;
 
 class GroovyShellCommand implements Command {
 
@@ -36,14 +32,14 @@ class GroovyShellCommand implements Command {
   private ExitCallback callback;
   private Thread wrapper;
   private ChannelSession session;
-  private final AtomicBoolean isChannelAlive;
+  private final AtomicBoolean isServiceAlive;
 
   GroovyShellCommand(SshServer sshd, Map<String, Object> bindings, List<String> defaultScripts,
-      AtomicBoolean isChannelAlive) {
+      AtomicBoolean isServiceAlive) {
     this.sshd = sshd;
     this.bindings = bindings;
     this.defaultScripts = defaultScripts;
-    this.isChannelAlive = isChannelAlive;
+    this.isServiceAlive = isServiceAlive;
   }
 
   @Override
@@ -69,8 +65,8 @@ class GroovyShellCommand implements Command {
   @Override
   public void start(ChannelSession session, Environment env) throws IOException {
     this.session = session;
-    TtyFilterOutputStream out = new TtyFilterOutputStream(this.out, isChannelAlive);
-    TtyFilterOutputStream err = new TtyFilterOutputStream(this.err, isChannelAlive);
+    TtyFilterOutputStream out = new TtyFilterOutputStream(this.out, isServiceAlive);
+    TtyFilterOutputStream err = new TtyFilterOutputStream(this.err, isServiceAlive);
 
     IO io = new IO(in, out, err);
     io.setVerbosity(DEBUG);

--- a/groovy-shell-server/src/main/java/me/bazhenov/groovysh/Main.java
+++ b/groovy-shell-server/src/main/java/me/bazhenov/groovysh/Main.java
@@ -1,8 +1,8 @@
 package me.bazhenov.groovysh;
 
-import static java.lang.Thread.currentThread;
-
 import java.io.IOException;
+
+import static java.lang.Thread.currentThread;
 
 public class Main {
 

--- a/groovy-shell-server/src/main/java/me/bazhenov/groovysh/spring/GroovyShellServiceBean.java
+++ b/groovy-shell-server/src/main/java/me/bazhenov/groovysh/spring/GroovyShellServiceBean.java
@@ -1,9 +1,5 @@
 package me.bazhenov.groovysh.spring;
 
-import static java.util.Arrays.asList;
-
-import java.util.HashMap;
-import java.util.Map;
 import me.bazhenov.groovysh.GroovyShellService;
 import org.apache.sshd.server.auth.password.PasswordAuthenticator;
 import org.springframework.beans.BeansException;
@@ -12,6 +8,11 @@ import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static java.util.Arrays.asList;
 
 @SuppressWarnings("UnusedDeclaration")
 public class GroovyShellServiceBean implements InitializingBean, DisposableBean,
@@ -32,6 +33,10 @@ public class GroovyShellServiceBean implements InitializingBean, DisposableBean,
 
   public void setPort(int port) {
     service.setPort(port);
+  }
+
+  public void setIdleTimeOut(long timeout) {
+    service.setIdleTimeOut(timeout);
   }
 
   /**


### PR DESCRIPTION
There is the problem with groovy-shell. It produce endless cycle log messages when idle timeout happens before the shell produce any output.
This pull request fixes the problem.

In addition a client can configure idle timeout for the shell.