### PR TITLE
Update for Spring Boot 3

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -81,6 +81,22 @@ You can easily integrate Groovy Shell with Spring container:
 		<entry key="foo" value="bar"/>
 	</u:map>
 
+For modern annotation based bean declaration you can use:
+
+    @Bean
+    public GroovyShellServiceBean groovyShellServiceBean() {
+        GroovyShellServiceBean groovyShellServiceBean = new GroovyShellServiceBean();
+        groovyShellServiceBean.setIdleTimeOut(Duration.ofMinutes(groovyShellTimeoutMinutes).toMillis());
+        groovyShellServiceBean.setPort(groovyShellPort);
+        groovyShellServiceBean.setLaunchAtStart(true);
+        groovyShellServiceBean.setPublishContextBeans(true);
+        groovyShellServiceBean.setBindings(new HashMap<String, Object>() {{
+            put("foo", obj1);
+            put("bar", obj2);
+        }});
+        return groovyShellServiceBean;
+    }
+
 When `publishContextBeans` is true all context beans are published to groovy shell context. So bean with id `foo`
 will be available as `foo` in groovy shell. Also reference to the `ApplicationContext` is added to bindings implicitly
 as `ctx`. So in shell you can get objects from container by id or type (e.g. `ctx.getBean('id')`).

--- a/groovy-shell-server/pom.xml
+++ b/groovy-shell-server/pom.xml
@@ -11,7 +11,7 @@
 	</parent>
 
 	<properties>
-		<versions.groovy>3.0.8</versions.groovy>
+		<versions.groovy>3.0.24</versions.groovy>
 	</properties>
 
 	<dependencies>
@@ -34,25 +34,17 @@
 		<dependency>
 			<groupId>org.apache.sshd</groupId>
 			<artifactId>sshd-core</artifactId>
-			<version>2.7.0</version>
+			<version>2.15.0</version>
 			<exclusions>
 				<exclusion>
 					<artifactId>slf4j-api</artifactId>
 					<groupId>org.slf4j</groupId>
 				</exclusion>
+				<exclusion>
+					<artifactId>slf4j-api</artifactId>
+					<groupId>jcl-over-slf4j</groupId>
+				</exclusion>
 			</exclusions>
-		</dependency>
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-api</artifactId>
-			<version>1.7.32</version>
-		</dependency>
-		<dependency>
-			<groupId>ch.qos.logback</groupId>
-			<artifactId>logback-classic</artifactId>
-			<version>1.2.6</version>
-			<scope>runtime</scope>
-			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>jline</groupId>

--- a/groovy-shell-server/pom.xml
+++ b/groovy-shell-server/pom.xml
@@ -40,11 +40,19 @@
 					<artifactId>slf4j-api</artifactId>
 					<groupId>org.slf4j</groupId>
 				</exclusion>
-				<exclusion>
-					<artifactId>slf4j-api</artifactId>
-					<groupId>jcl-over-slf4j</groupId>
-				</exclusion>
 			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+			<version>2.0.17</version>
+		</dependency>
+		<dependency>
+			<groupId>ch.qos.logback</groupId>
+			<artifactId>logback-classic</artifactId>
+			<version>1.5.18</version>
+			<scope>runtime</scope>
+			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>jline</groupId>


### PR DESCRIPTION
The current version is not compatible with spring boot 3.x . This PR would propose changes that would make this library compatible with Spring Boot 3.

Upgrading groovy version solved the connection closed by remote host problem which was caused by
```
2025-05-11T21:40:03.759+02:00  WARN 195781 --- [)-nio2-thread-3] o.a.s.server.session.ServerSessionImpl   : exceptionCaught(ServerSessionImpl[s.suter@/127.0.0.1:36332])[state=Opened] RuntimeSshException: null
2025-05-11T21:40:03.763+02:00  WARN 195781 --- [)-nio2-thread-3] o.a.sshd.server.channel.ChannelSession   : doCloseImmediately(ChannelSession[id=0, recipient=0]-ServerSessionImpl[s.suter@/127.0.0.1:36332]) failed (NullPointerException) to destroy command: Cannot invoke "java.lang.Thread.interrupt()" because "this.wrapper" is null
```
`slf4j` caused static binding issues
```
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
Exception in thread "main" java.lang.IllegalArgumentException: LoggerFactory is not a Logback LoggerContext but Logback is on the classpath. Either remove Logback or the competing implementation (class org.slf4j.helpers.NOPLoggerFactory loaded from file:/home/s.suter/.m2/repository/org/slf4j/slf4j-api/1.7.32/slf4j-api-1.7.32.jar). If you are using WebLogic you will need to add 'org.slf4j' to prefer-application-packages in WEB-INF/weblogic.xml: org.slf4j.helpers.NOPLoggerFactory
```

Changes:
Upgrading Groovy and Groovy shell version to the latest one
Removing slf4j dependencies.

